### PR TITLE
Add basic login UI

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,17 +1,22 @@
 import { Routes, Route } from 'react-router-dom'
 import { Workflows } from './pages/Workflows'
 import { Dashboard } from './pages/Dashboard'
+import { Login } from './pages/Login'
 import { Layout } from './components/Layout'
+import { AuthProvider } from './contexts/AuthContext'
 
 function App() {
   return (
-    <Layout>
-      <Routes>
-        <Route path="/" element={<Dashboard />} />
-        <Route path="/workflows" element={<Workflows />} />
-      </Routes>
-    </Layout>
+    <AuthProvider>
+      <Layout>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/workflows" element={<Workflows />} />
+        </Routes>
+      </Layout>
+    </AuthProvider>
   )
 }
 
-export default App 
+export default App

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from 'react-router-dom'
 import { Workflow, BarChart3, Settings } from 'lucide-react'
+import { useAuth } from '../contexts/AuthContext'
 
 interface LayoutProps {
   children: React.ReactNode
@@ -7,6 +8,7 @@ interface LayoutProps {
 
 export function Layout({ children }: LayoutProps) {
   const location = useLocation()
+  const { user, logout } = useAuth()
 
   const navigation = [
     { name: 'Dashboard', href: '/', icon: BarChart3 },
@@ -40,6 +42,17 @@ export function Layout({ children }: LayoutProps) {
                 </Link>
               )
             })}
+          </div>
+          <div className="mt-6 px-3">
+            {user ? (
+              <button onClick={logout} className="btn-secondary w-full">
+                Logout
+              </button>
+            ) : (
+              <Link to="/login" className="btn-primary w-full text-center">
+                Login
+              </Link>
+            )}
           </div>
         </nav>
       </div>

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useState } from 'react'
+import axios from 'axios'
+
+interface User {
+  id: string
+  email: string
+}
+
+interface AuthContextValue {
+  user: User | null
+  login: (email: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null)
+
+  const login = async (email: string, password: string) => {
+    await axios.post('/api/auth/login', { email, password })
+    setUser({ id: '1', email })
+  }
+
+  const logout = () => {
+    setUser(null)
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -1,0 +1,50 @@
+import { FormEvent, useState } from 'react'
+import { useAuth } from '../contexts/AuthContext'
+
+export function Login() {
+  const { login } = useAuth()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    try {
+      await login(email, password)
+    } catch {
+      setError('Invalid credentials')
+    }
+  }
+
+  return (
+    <div className="max-w-md mx-auto">
+      <h1 className="text-3xl font-bold mb-4">Login</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm"
+            required
+          />
+        </div>
+        <button type="submit" className="btn-primary w-full">
+          Sign In
+        </button>
+      </form>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `AuthContext` for login state
- add login page and authentication routes
- show login/logout button in sidebar

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run type-check` *(fails: missing script)*
- `npm run build` *(fails: TypeScript errors)*
- `npm run test:auth` *(fails: missing script)*
- `go fmt ./...`
- `go vet ./...`
- `golint ./...` *(fails: command not found)*
- `go test -race ./...`
- `go test -bench=. ./auth/...` *(fails: no auth module)*
- `gosec ./...` *(fails: command not found)*
- `npm audit` *(fails: blocked by network)*
- `docker scout cves` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee4da08bc832790cb933457561de0